### PR TITLE
Updates for release of BouncyCastle 1.56

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -49,6 +49,11 @@ maven_jar(
 )
 
 maven_jar(
+    name = "bouncycastle_1_56",
+    artifact = "org.bouncycastle:bcprov-jdk15on:1.56",
+)
+
+maven_jar(
     name = "spongycastle_core_1_50",
     artifact = "com.madgag.spongycastle:core:1.50.0.0",
 )

--- a/build_defs.bzl
+++ b/build_defs.bzl
@@ -1,10 +1,10 @@
-bouncycastle_versions = range(49, 56)
+bouncycastle_versions = range(49, 57)
 
 # These targets run all tests.
 def bouncycastle_all_tests(srcs, deps, size, test_class):
   """BouncyCastle version-specific tests."""
 
-  # Generates BouncyCastleAllTests_1_55, ..., BouncyCastleAllTests_1_49
+  # Generates BouncyCastleAllTests_1_56, ..., BouncyCastleAllTests_1_49
   for version in bouncycastle_versions:
     native.java_test(
         name = "BouncyCastleAllTests_1_%s" % version,
@@ -31,7 +31,7 @@ def bouncycastle_all_tests(srcs, deps, size, test_class):
 def bouncycastle_tests(srcs, deps, size, test_class):
   """BouncyCastle version-specific tests."""
 
-  # Generates BouncyCastleTest_1_55, ..., BouncyCastleTest_1_49
+  # Generates BouncyCastleTest_1_56, ..., BouncyCastleTest_1_49
   for version in bouncycastle_versions:
     native.java_test(
         name = "BouncyCastleTest_1_%s" % version,

--- a/java/com/google/security/wycheproof/testcases/DhiesTest.java
+++ b/java/com/google/security/wycheproof/testcases/DhiesTest.java
@@ -68,9 +68,9 @@ public class DhiesTest extends TestCase {
   }
 
   /**
-   * WARNING: This test uses weak crypto (i.e. DHIESWithAES). Checks that key agreement using DHIES
-   * works in the sense that it can decrypt what it encrypts. Unfortunately it seems that there is
-   * no secure mode using AES.
+   * WARNING: This test uses weak crypto (i.e. DHIESWithAES), if supported. Checks that key agreement
+   * using DHIES works in the sense that it can decrypt what it encrypts. Unfortunately it seems that
+   * there is no secure mode using AES.
    */
   @SuppressWarnings("InsecureCipherMode")
   public void testDhiesBasic() throws Exception {
@@ -81,7 +81,13 @@ public class DhiesTest extends TestCase {
     PrivateKey priv = keyPair.getPrivate();
     PublicKey pub = keyPair.getPublic();
     byte[] message = "Hello".getBytes("UTF-8");
-    Cipher dhies = Cipher.getInstance("DHIESwithAES");
+    Cipher dhies;
+    try {
+      dhies = Cipher.getInstance("DHIESwithAES");
+    } catch (NoSuchAlgorithmException ex) {
+      // The algorithm isn't supported - even better!
+      return;
+    }
     dhies.init(Cipher.ENCRYPT_MODE, pub);
     byte[] ciphertext = dhies.doFinal(message);
     System.out.println("testDhiesBasic:" + TestUtil.bytesToHex(ciphertext));
@@ -103,7 +109,13 @@ public class DhiesTest extends TestCase {
     PrivateKey priv = keyPair.getPrivate();
     PublicKey pub = keyPair.getPublic();
     byte[] message = new byte[32];
-    Cipher dhies = Cipher.getInstance("DHIESwithAES");
+    Cipher dhies;
+    try {
+      dhies = Cipher.getInstance("DHIESwithAES");
+    } catch (NoSuchAlgorithmException ex) {
+      // The algorithm isn't supported - even better!
+      return;
+    }
     dhies.init(Cipher.ENCRYPT_MODE, pub);
     byte[] ciphertext = dhies.doFinal(message);
     for (int i = 0; i < ciphertext.length; i++) {

--- a/java/com/google/security/wycheproof/testcases/EciesTest.java
+++ b/java/com/google/security/wycheproof/testcases/EciesTest.java
@@ -17,6 +17,7 @@
 package com.google.security.wycheproof;
 
 import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -81,7 +82,7 @@ public class EciesTest extends TestCase {
     ecies.init(Cipher.ENCRYPT_MODE, pub);
     byte[] ciphertext = ecies.doFinal(message);
     System.out.println("testEciesBasic:" + TestUtil.bytesToHex(ciphertext));
-    ecies.init(Cipher.DECRYPT_MODE, priv);
+    ecies.init(Cipher.DECRYPT_MODE, priv, ecies.getParameters());
     byte[] decrypted = ecies.doFinal(ciphertext);
     assertEquals(TestUtil.bytesToHex(message), TestUtil.bytesToHex(decrypted));
   }
@@ -98,6 +99,8 @@ public class EciesTest extends TestCase {
         new String[] {
           "ECIESWITHAES/CBC/PKCS5PADDING",
           "ECIESWITHAES/CBC/PKCS7PADDING",
+          "ECIESWITHAES/DHAES/NOPADDING",
+          "ECIESWITHDESEDE/DHAES/NOPADDING",
           "ECIESWITHAES/ECB/NOPADDING",
           "ECIESWITHAES/CTR/NOPADDING",
         };
@@ -116,14 +119,12 @@ public class EciesTest extends TestCase {
   // expect.
   @SuppressWarnings("InsecureCipherMode")
   public void testValidNames() throws Exception {
-    String[] invalidNames =
+    String[] validNames =
         new String[] {
-          "ECIESWITHAES/DHAES/NOPADDING",
           "ECIES/DHAES/PKCS7PADDING",
-          "ECIESWITHDESEDE/DHAES/NOPADDING",
           "ECIESWITHAES-CBC/NONE/NOPADDING",
         };
-    for (String algorithm : invalidNames) {
+    for (String algorithm : validNames) {
       Cipher.getInstance(algorithm);
     }
   }
@@ -187,7 +188,7 @@ public class EciesTest extends TestCase {
     ecies.init(Cipher.ENCRYPT_MODE, pub);
     byte[] ciphertext = ecies.doFinal(message);
     System.out.println(TestUtil.bytesToHex(ciphertext));
-    ecies.init(Cipher.DECRYPT_MODE, priv);
+    ecies.init(Cipher.DECRYPT_MODE, priv, ecies.getParameters());
     HashSet<String> exceptions = new HashSet<String>();
     for (int byteNr = kemSize; byteNr < ciphertext.length; byteNr++) {
       for (int bit = 0; bit < 8; bit++) {
@@ -225,13 +226,15 @@ public class EciesTest extends TestCase {
     ecies.init(Cipher.ENCRYPT_MODE, pub);
     byte[] ciphertext = ecies.doFinal(message);
     ciphertext[2] ^= (byte) 1;
-    ecies.init(Cipher.DECRYPT_MODE, priv);
+    ecies.init(Cipher.DECRYPT_MODE, priv, ecies.getParameters());
     try {
       ecies.doFinal(ciphertext);
       fail("This should not work");
-    } catch (java.lang.IllegalArgumentException ex) {
-      // This is what BouncyCastle throws when the points are not on the curve.
-      // Maybe GeneralSecurityException would be better.
+    } catch (GeneralSecurityException ex) {
+      // This is as expected
+    } catch (Exception ex) {
+      fail("Expected subclass of java.security.GeneralSecurityException, but got: "
+        + ex.getClass().getName());
     }
   }
 
@@ -296,7 +299,7 @@ public class EciesTest extends TestCase {
     byte[] message = "Hello".getBytes("UTF-8");
     eciesA.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
     byte[] ciphertext = eciesA.doFinal(message);
-    eciesB.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+    eciesB.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), eciesA.getParameters());
     byte[] decrypted = eciesB.doFinal(ciphertext);
     assertEquals(TestUtil.bytesToHex(message), TestUtil.bytesToHex(decrypted));
   }


### PR DESCRIPTION
- add maven entry for BC 1.56 and update the versions range
- DHIES weak crypto tests now pass if algs not even supported
- some ECIES entries moved to the invalid list
- ECIES decryption init calls fixed to pass the correct parameters
- EciesTest.testModifyPoint now expects GeneralSecurityException