### PR TITLE
Option to test a local BouncyCastle jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ bazel test BouncyCastleAllTests_1_52
 bazel test BouncyCastleAllTests_*
 ```
 
+- To test a local jar
+
+``` shell
+bazel test BouncyCastleAllTestsLocal --define BOUNCYCASTLE_JAR=/path/to/bouncycastle
+```
+
 - To test [Spongy Castle](https://rtyley.github.io/spongycastle/), replace
 BouncyCastle with SpongyCastle in your commands, for example
 


### PR DESCRIPTION
Resolves Github issue #4

This is a bit of a hack. I can't find a way to supply the jar directly
from the command line to the 'deps' or 'srcs' of a rule, so we create
an intermediate symlink.

Also, we need to define a separate build target. It'd be nicer to use
config_setting to switch between local and remote jars - but macros
don't support command-line flags, which makes this awkward.