### PR TITLE
RSA decryption tests with specific PKCS#1 valid/inalid values

### DIFF
--- a/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
+++ b/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
@@ -116,7 +116,7 @@ public class RsaEncryptionTest extends TestCase {
       }
     }
     Cipher enc = Cipher.getInstance("RSA/ECB/NOPADDING");
-    enc.init(Cipher.ENCRYPT_MODE, keypair.getPrivate());
+    enc.init(Cipher.ENCRYPT_MODE, keypair.getPublic());
     c.init(Cipher.DECRYPT_MODE, keypair.getPrivate());
     byte[][] paddedKeys = generatePkcs1Vectors(1024 / 8);
     for (int i = 0; i < paddedKeys.length; i++) {

--- a/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
+++ b/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
@@ -20,6 +20,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.HashSet;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
@@ -114,6 +115,18 @@ public class RsaEncryptionTest extends TestCase {
         exceptions.add(ex.toString());
       }
     }
+    Cipher enc = Cipher.getInstance("RSA/ECB/NOPADDING");
+    enc.init(Cipher.ENCRYPT_MODE, keypair.getPrivate());
+    c.init(Cipher.DECRYPT_MODE, keypair.getPrivate());
+    byte[][] paddedKeys = generatePkcs1Vectors(1024 / 8);
+    for (int i = 0; i < paddedKeys.length; i++) {
+      ciphertext = enc.doFinal(paddedKeys[i]);
+      try {
+        c.doFinal(ciphertext);
+      } catch (Exception ex) {
+        exceptions.add(ex.toString());
+      }
+    }
     if (exceptions.size() > 1) {
       System.out.println("Exceptions for " + algorithm);
       for (String s : exceptions) {
@@ -134,5 +147,81 @@ public class RsaEncryptionTest extends TestCase {
 
   public void testGetExceptionsOAEP() throws Exception {
     testExceptions("RSA/ECB/OAEPWITHSHA-1ANDMGF1PADDING");
+  }
+  
+  /**
+   * Generates PKCS#1 invalid vectors
+   * @param rsaKeyLength
+   * @return 
+  */
+  private byte[][] generatePkcs1Vectors(int rsaKeyLength) {
+    // create plain padded keys
+    byte[][] plainPaddedKeys = new byte[13][];
+    // no 0x00 byte to deliver a symmetric key
+    plainPaddedKeys[0] = getEK_NoNullByte(rsaKeyLength);
+    // 0x00 too early in the padding
+    plainPaddedKeys[1] = getEK_NullByteInPadding(rsaKeyLength);
+    // 0x00 too early in the PKCS#1 padding
+    plainPaddedKeys[2] = getEK_NullByteInPkcsPadding(rsaKeyLength);
+    // decrypted ciphertext starting with 0x17 0x02
+    plainPaddedKeys[3] = getEK_WrongFirstByte(rsaKeyLength);
+    // decrypted ciphertext starting with 0x00 0x17
+    plainPaddedKeys[4] = getEK_WrongSecondByte(rsaKeyLength);
+    // different lengths of the decrypted unpadded key
+    plainPaddedKeys[5] = getPaddedKey(rsaKeyLength, 0);
+    plainPaddedKeys[6] = getPaddedKey(rsaKeyLength, 1);
+    plainPaddedKeys[7] = getPaddedKey(rsaKeyLength, 8);
+    plainPaddedKeys[8] = getPaddedKey(rsaKeyLength, 16);
+    plainPaddedKeys[9] = getPaddedKey(rsaKeyLength, 96);
+    // the decrypted padded plaintext is shorter than RSA key
+    plainPaddedKeys[10] = getPaddedKey(rsaKeyLength - 1, 16);
+    plainPaddedKeys[11] = getPaddedKey(rsaKeyLength - 2, 16);
+    // just 0x00 bytes
+    plainPaddedKeys[12] = new byte[rsaKeyLength];
+    return plainPaddedKeys;
+  }
+
+  private byte[] getPaddedKey(int rsaKeyLength, int symmetricKeyLength) {
+    byte[] key = new byte[rsaKeyLength];
+    // fill all the bytes with non-zero values
+    Arrays.fill(key, (byte) 42);
+    // set the first byte to 0x00
+    key[0] = 0x00;
+    // set the second byte to 0x02
+    key[1] = 0x02;
+    // set the separating byte
+    if(symmetricKeyLength != -1) {
+      key[rsaKeyLength - symmetricKeyLength - 1] = 0x00;
+    }    
+    return key;
+  }
+
+  private byte[] getEK_WrongFirstByte(int rsaKeyLength) {
+    byte[] key = getPaddedKey(rsaKeyLength, 16);
+    key[0] = 23;
+    return key;
+  }
+
+  private byte[] getEK_WrongSecondByte(int rsaKeyLength) {
+    byte[] key = getPaddedKey(rsaKeyLength, 16);
+    key[1] = 23;
+    return key;
+  }
+
+  private byte[] getEK_NoNullByte(int rsaKeyLength) {
+    byte[] key = getPaddedKey(rsaKeyLength, -1);
+    return key;
+  }
+
+  private byte[] getEK_NullByteInPkcsPadding(int rsaKeyLength) {
+    byte[] key = getPaddedKey(rsaKeyLength, 16);
+    key[3] = 0x00;
+    return key;
+  }
+
+  private byte[] getEK_NullByteInPadding(int rsaKeyLength) {
+    byte[] key = getPaddedKey(rsaKeyLength, 16);
+    key[11] = 0x00;
+    return key;
   }
 }


### PR DESCRIPTION
I think it covers most of the test vectors from the recent papers.

It could be considered to add these tests for other key sizes as well, not only for 1024-bit RSA keys. In https://www.nds.rub.de/research/publications/mswsst2014-bleichenbacher-usenix14/ we could experience different behaviour of the decryptors while working with different key sizes.