### PR TITLE
Fixed #38 - JUnit3 runner is being used instead of JUnit4

### DIFF
--- a/java/com/google/security/wycheproof/testcases/AesEaxTest.java
+++ b/java/com/google/security/wycheproof/testcases/AesEaxTest.java
@@ -22,13 +22,15 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /** AES-EAX tests */
-public class AesEaxTest extends TestCase {
+public class AesEaxTest {
 
   /** Test vectors */
   public static class EaxTestVector {
@@ -264,6 +266,7 @@ public class AesEaxTest extends TestCase {
     }
   }
 
+  @Test
   public void testLateUpdateAAD() throws Exception {
     for (EaxTestVector test : EAX_TEST_VECTOR) {
       Cipher cipher = Cipher.getInstance("AES/EAX/NoPadding");

--- a/java/com/google/security/wycheproof/testcases/AesGcmTest.java
+++ b/java/com/google/security/wycheproof/testcases/AesGcmTest.java
@@ -16,7 +16,7 @@
 
 package com.google.security.wycheproof;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.*;
 
 import com.google.security.wycheproof.WycheproofRunner.ExcludedTest;
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
@@ -35,7 +35,7 @@ import javax.crypto.ShortBufferException;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 // TODO(bleichen):
 //   - For EAX I was able to derive some special cases by inverting OMAC.
@@ -45,7 +45,7 @@ import junit.framework.TestCase;
  *
  * <p>Other tests using AES-GCM are: CipherInputStreamTest.java CipherOuputStreamTest.java
  */
-public class AesGcmTest extends TestCase {
+public class AesGcmTest {
 
   /** Test vectors */
   public static class GcmTestVector {
@@ -182,6 +182,7 @@ public class AesGcmTest extends TestCase {
     return supported;
   }
 
+  @Test
   public void testVectors() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
@@ -203,6 +204,7 @@ public class AesGcmTest extends TestCase {
    * <p>For example BouncyCastle computes correct tags if the calls are reversed, SunJCE and OpenJdk
    * now throw exceptions.
    */
+  @Test
   public void testLateUpdateAAD() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
@@ -235,6 +237,7 @@ public class AesGcmTest extends TestCase {
    *
    * <p>Conscrypt failed this test
    */
+  @Test
   public void testIvReuse() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
@@ -256,6 +259,7 @@ public class AesGcmTest extends TestCase {
   }
 
   /** Encryption with ByteBuffers. */
+  @Test
   public void testByteBuffer() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       // Encryption
@@ -280,6 +284,7 @@ public class AesGcmTest extends TestCase {
   }
 
   /** Encryption with ByteBuffers should be copy-safe. */
+  @Test
   public void testByteBufferAlias() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       // Encryption
@@ -306,6 +311,7 @@ public class AesGcmTest extends TestCase {
   }
 
   /** Encryption and decryption with large arrays should be copy-safe. */
+  @Test
   public void testLargeArrayAlias() throws Exception {
     byte[] ptVector = new byte[8192];
 
@@ -370,6 +376,7 @@ public class AesGcmTest extends TestCase {
    *
    * @see https://bugs.openjdk.java.net/browse/JDK-8181386
    */
+  @Test
   public void testByteBufferShiftedAlias() throws Exception {
     byte[] ptVector = new byte[8192];
 
@@ -471,6 +478,7 @@ public class AesGcmTest extends TestCase {
 
   }
 
+  @Test
   public void testReadOnlyByteBuffer() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       // Encryption
@@ -500,6 +508,7 @@ public class AesGcmTest extends TestCase {
    * through the .array() method. An implementation using this possiblity must ensure that it
    * considers the offset.
    */
+  @Test
   public void testByteBufferWithOffset() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       // Encryption
@@ -530,6 +539,7 @@ public class AesGcmTest extends TestCase {
     }
   }
 
+  @Test
   public void testByteBufferTooShort() throws Exception {
     for (GcmTestVector test : getTestVectors()) {
       // Encryption
@@ -570,6 +580,7 @@ public class AesGcmTest extends TestCase {
    * another provider. Such a switch should ideally not lower the security. <br>
    * Conscrypt used to have only 12-byte authentication tag (b/26186727).
    */
+  @Test
   public void testDefaultTagSizeIvParameterSpec() throws Exception {
     byte[] counter = new byte[12];
     byte[] input = new byte[16];
@@ -597,6 +608,7 @@ public class AesGcmTest extends TestCase {
    * another provider. Such a switch should ideally not lower the security. <br>
    * BouncyCastle used to have only 12-byte authentication tag (b/26186727).
    */
+  @Test
   public void testDefaultTagSizeAlgorithmParameterGenerator() throws Exception {
     byte[] input = new byte[10];
     byte[] key = new byte[16];
@@ -652,6 +664,7 @@ public class AesGcmTest extends TestCase {
     comment = "Conscrypt doesn't support streaming, would crash")
   @SlowTest(
     providers = {ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE, ProviderType.OPENJDK})
+  @Test
   public void testWrappedAroundCounter() throws Exception {
     try {
       byte[] iv = new byte[12];

--- a/java/com/google/security/wycheproof/testcases/BasicTest.java
+++ b/java/com/google/security/wycheproof/testcases/BasicTest.java
@@ -16,15 +16,18 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.security.Provider;
 import java.security.Security;
 import java.util.TreeSet;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /** Not a true test: reports information about the provider. */
-public class BasicTest extends TestCase {
+public class BasicTest {
 
   /** List all algorithms known to the security manager. */
+  @Test
   public void testListAllAlgorithms() {
     for (Provider p : Security.getProviders()) {
       System.out.println();

--- a/java/com/google/security/wycheproof/testcases/BigIntegerTest.java
+++ b/java/com/google/security/wycheproof/testcases/BigIntegerTest.java
@@ -16,15 +16,17 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.math.BigInteger;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Test BigInteger class.
  *
  * <p>This unit tests focuses on checking security relevant properties.
  */
-public class BigIntegerTest extends TestCase {
+public class BigIntegerTest {
   public static final BigInteger[] NONPRIMES =
       new BigInteger[] {
         // small non prime integers
@@ -444,6 +446,7 @@ public class BigIntegerTest extends TestCase {
    * Lucas test. This is similar to the Baillie-PSW test
    * https://en.wikipedia.org/wiki/Baillie%E2%80%93PSW_primality_test
    */
+  @Test
   public void testIsProbablePrime() throws Exception {
     // The probability that a non-prime passes should be at most 1-2^{-certainty}.
     int certainty = 80;

--- a/java/com/google/security/wycheproof/testcases/CipherInputStreamTest.java
+++ b/java/com/google/security/wycheproof/testcases/CipherInputStreamTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,10 +30,10 @@ import javax.crypto.Cipher;
 import javax.crypto.CipherInputStream;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /** CipherInputStream tests */
-public class CipherInputStreamTest extends TestCase {
+public class CipherInputStreamTest {
   static final SecureRandom rand = new SecureRandom();
 
   static byte[] randomBytes(int size) {
@@ -217,6 +219,7 @@ public class CipherInputStreamTest extends TestCase {
     }
   }
 
+  @Test
   public void testAesGcm() throws Exception {
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
@@ -229,6 +232,7 @@ public class CipherInputStreamTest extends TestCase {
     testDecrypt(v);
   }
 
+  @Test
   public void testCorruptAesGcm() throws Exception {
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
@@ -245,6 +249,7 @@ public class CipherInputStreamTest extends TestCase {
    * ciphertexts. Because of this we test empty plaintext separately to distinguish behaviour
    * considered acceptable by Oracle from other behaviour.
    */
+  @Test
   public void testEmptyPlaintext() throws Exception {
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
@@ -257,6 +262,7 @@ public class CipherInputStreamTest extends TestCase {
   }
 
   /** Tests CipherOutputStream with AES-EAX if this algorithm is supported by the provider. */
+  @Test
   public void testAesEax() throws Exception {
     final String algorithm = "AES/EAX/NoPadding";
     final int[] keySizes = {16, 32};

--- a/java/com/google/security/wycheproof/testcases/CipherOutputStreamTest.java
+++ b/java/com/google/security/wycheproof/testcases/CipherOutputStreamTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
@@ -27,10 +29,10 @@ import javax.crypto.Cipher;
 import javax.crypto.CipherOutputStream;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /** CipherOutputStream tests */
-public class CipherOutputStreamTest extends TestCase {
+public class CipherOutputStreamTest {
   static final SecureRandom rand = new SecureRandom();
 
   static byte[] randomBytes(int size) {
@@ -184,6 +186,7 @@ public class CipherOutputStreamTest extends TestCase {
     }
   }
 
+  @Test
   public void testAesGcm() throws Exception {
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
@@ -202,6 +205,7 @@ public class CipherOutputStreamTest extends TestCase {
    * ciphertexts. Because of this we test empty plaintext separately to distinguish behaviour
    * considered acceptable by Oracle from other behaviour.
    */
+  @Test
   public void testEmptyPlaintext() throws Exception {
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
@@ -217,6 +221,7 @@ public class CipherOutputStreamTest extends TestCase {
 
   /** Tests CipherOutputStream with AES-EAX if AES-EAS is supported by the provider. */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testAesEax() throws Exception {
     final String algorithm = "AES/EAX/NoPadding";
     final int[] keySizes = {16, 32};

--- a/java/com/google/security/wycheproof/testcases/DhTest.java
+++ b/java/com/google/security/wycheproof/testcases/DhTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import com.google.security.wycheproof.WycheproofRunner.SlowTest;
 import java.math.BigInteger;
@@ -29,7 +31,7 @@ import javax.crypto.KeyAgreement;
 import javax.crypto.interfaces.DHPrivateKey;
 import javax.crypto.spec.DHParameterSpec;
 import javax.crypto.spec.DHPublicKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Testing Diffie-Hellman key agreement.
@@ -138,7 +140,7 @@ import junit.framework.TestCase;
  *
  * @author bleichen@google.com (Daniel Bleichenbacher)
  */
-public class DhTest extends TestCase {
+public class DhTest {
   public DHParameterSpec ike1536() {
     final BigInteger p =
         new BigInteger(
@@ -193,6 +195,7 @@ public class DhTest extends TestCase {
 
   /** Check that key agreement using DH works. */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testDh() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DH");
     DHParameterSpec dhparams = ike2048();
@@ -323,6 +326,7 @@ public class DhTest extends TestCase {
    */
   @SuppressWarnings("InsecureCryptoUsage")
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE})
+  @Test
   public void testKeyPairGenerator() throws Exception {
     int keySize = 1024;
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DH");
@@ -333,6 +337,7 @@ public class DhTest extends TestCase {
 
   /** This test tries a key agreement with keys using distinct parameters. */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testDHDistinctParameters() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DH");
     keyGen.initialize(ike1536());
@@ -366,6 +371,7 @@ public class DhTest extends TestCase {
    * <p> CVE-2016-1000346: BouncyCastle before v.1.56 did not validate the other parties public key.
    */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testSubgroupConfinement() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("DH");
     DHParameterSpec params = ike2048();

--- a/java/com/google/security/wycheproof/testcases/DhiesTest.java
+++ b/java/com/google/security/wycheproof/testcases/DhiesTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import com.google.security.wycheproof.WycheproofRunner.SlowTest;
 import java.math.BigInteger;
@@ -28,7 +30,7 @@ import java.security.PublicKey;
 import java.util.Arrays;
 import javax.crypto.Cipher;
 import javax.crypto.spec.DHParameterSpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Testing DHIES.
@@ -47,7 +49,7 @@ import junit.framework.TestCase;
 //   Cipher.DHIESWITHAES-CBC.
 // - So far only BouncyCastles is tesed because this is the only provider
 //   we use that implements DHIES.
-public class DhiesTest extends TestCase {
+public class DhiesTest {
 
   // TODO(bleichen): This is the same as DhTest.java
   //   We could move this into some TestUtil.
@@ -76,6 +78,7 @@ public class DhiesTest extends TestCase {
    * seems that there is no secure mode using AES.
    */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testDhiesBasic() throws Exception {
     DHParameterSpec params = ike2048();
     KeyPairGenerator kf = KeyPairGenerator.getInstance("DH");
@@ -105,6 +108,7 @@ public class DhiesTest extends TestCase {
    */
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE})
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testDhiesCorrupt() throws Exception {
     KeyPairGenerator kf = KeyPairGenerator.getInstance("DH");
     kf.initialize(ike2048());
@@ -166,6 +170,7 @@ public class DhiesTest extends TestCase {
     }
   }
 
+  @Test
   public void testSemanticSecurityDhies() throws Exception {
     testNotEcb("DHIES");
   }

--- a/java/com/google/security/wycheproof/testcases/DsaTest.java
+++ b/java/com/google/security/wycheproof/testcases/DsaTest.java
@@ -26,6 +26,8 @@
 //       signature multiple times, since this allows to get more accurate timings.
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import com.google.security.wycheproof.WycheproofRunner.SlowTest;
 import java.lang.management.ManagementFactory;
@@ -47,7 +49,7 @@ import java.security.spec.DSAPrivateKeySpec;
 import java.security.spec.DSAPublicKeySpec;
 import java.util.Arrays;
 import javax.crypto.Cipher;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Tests DSA against invalid signatures. The motivation for this test is the DSA implementation in
@@ -55,7 +57,7 @@ import junit.framework.TestCase;
  *
  * @author bleichen@google.com (Daniel Bleichenbacher)
  */
-public class DsaTest extends TestCase {
+public class DsaTest {
   static final String MESSAGE = "Hello";
 
   static final DSAPrivateKeySpec privateKey1 =
@@ -716,17 +718,20 @@ public class DsaTest extends TestCase {
     assertEquals(0, errors);
   }
 
+  @Test
   public void testValidSignatures() throws Exception {
     testVectors(
         VALID_SIGNATURES, publicKey1, "Hello", "SHA224WithDSA", "Valid DSA signature", true, true);
   }
 
+  @Test
   public void testModifiedSignatures() throws Exception {
     testVectors(
         MODIFIED_SIGNATURES, publicKey1, "Hello", "SHA224WithDSA", "Modified DSA signature",
         false, true);
   }
 
+  @Test
   public void testInvalidSignatures() throws Exception {
     testVectors(
         INVALID_SIGNATURES, publicKey1, "Hello", "SHA224WithDSA", "Invalid DSA signature",
@@ -772,6 +777,7 @@ public class DsaTest extends TestCase {
    * flaws. For example the SUN provider leaked the private keys with 3 to 5 signatures in such
    * instances.
    */
+  @Test
   public void testOutdatedProvider() throws Exception {
     try {
       Signature sig = Signature.getInstance("SHA1WithDSA");
@@ -792,6 +798,7 @@ public class DsaTest extends TestCase {
    */
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE})
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testBasic() throws Exception {
     int keySize = 2048;
     String algorithm = "SHA256WithDSA";
@@ -880,6 +887,7 @@ public class DsaTest extends TestCase {
    * </ul>
    */
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE})
+  @Test
   public void testKeyGenerationAll() throws Exception {
     testKeyGeneration(1024);
     testKeyGeneration(2048);
@@ -890,6 +898,7 @@ public class DsaTest extends TestCase {
    * test until April 2016.
    */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testDsaBias() throws Exception {
     // q is close to 2/3 * 2^160.
     BigInteger q = new BigInteger("974317976835659416858874959372334979171063697271");
@@ -967,6 +976,7 @@ public class DsaTest extends TestCase {
    */
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE})
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testBiasSha1WithDSA() throws Exception {
     String hashAlgorithm = "SHA";
     String message = "Hello";
@@ -1056,6 +1066,7 @@ public class DsaTest extends TestCase {
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.OPENJDK,
     ProviderType.SPONGY_CASTLE})
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testTiming() throws Exception {
     ThreadMXBean bean = ManagementFactory.getThreadMXBean();
     if (!bean.isCurrentThreadCpuTimeSupported()) {
@@ -1133,6 +1144,7 @@ public class DsaTest extends TestCase {
    * scheme that attempts to turn DSA into a public key encryption scheme.
    */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testEncryptionWithDsa() throws Exception {
     try {
       Cipher cipher = Cipher.getInstance("DSA");

--- a/java/com/google/security/wycheproof/testcases/EcKeyTest.java
+++ b/java/com/google/security/wycheproof/testcases/EcKeyTest.java
@@ -21,6 +21,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
@@ -34,10 +36,10 @@ import java.security.spec.ECPublicKeySpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /** EC tests */
-public class EcKeyTest extends TestCase {
+public class EcKeyTest {
   /**
    * Encodings of public keys with invalid parameters. There are multiple places where a provider
    * can validate a public key: some parameters are typically validated by the KeyFactory, more
@@ -127,6 +129,7 @@ public class EcKeyTest extends TestCase {
         + "8c0b49bbb85c3303ddb1553c3b761c2caacca71606ba9ebac8",
   };
 
+  @Test
   public void testEncodedPublicKey() throws Exception {
     KeyFactory kf = KeyFactory.getInstance("EC");
     for (String encodedHex : EC_INVALID_PUBLIC_KEYS) {
@@ -142,6 +145,7 @@ public class EcKeyTest extends TestCase {
     }
   }
 
+  @Test
   public void testEncodedPrivateKey() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
     keyGen.initialize(EcUtil.getNistP256Params());
@@ -185,6 +189,7 @@ public class EcKeyTest extends TestCase {
     // TODO(bleichen): use RandomUtil
   }
 
+  @Test
   public void testKeyGenerationAll() throws Exception {
     testKeyGeneration(EcUtil.getNistP224Params(), true);
     testKeyGeneration(EcUtil.getNistP256Params(), true);
@@ -202,6 +207,7 @@ public class EcKeyTest extends TestCase {
    * Nist recommends a minimal security strength of 112 bits for the time until 2030.
    * To achieve this security strength EC keys of at least 224 bits are required.
    */
+  @Test
   public void testDefaultKeyGeneration() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
     KeyPair keyPair = keyGen.generateKeyPair();
@@ -216,6 +222,7 @@ public class EcKeyTest extends TestCase {
    * Tries to generate a public key with a point at infinity. Public keys with a point at infinity
    * should be rejected to prevent subgroup confinement attacks.
    */
+  @Test
   public void testPublicKeyAtInfinity() throws Exception {
     ECParameterSpec ecSpec = EcUtil.getNistP256Params();
     try {

--- a/java/com/google/security/wycheproof/testcases/EcdhTest.java
+++ b/java/com/google/security/wycheproof/testcases/EcdhTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
@@ -35,7 +37,7 @@ import java.security.spec.EllipticCurve;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import javax.crypto.KeyAgreement;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Testing ECDH.
@@ -75,7 +77,7 @@ import junit.framework.TestCase;
 //     certificate.
 //   - CVE-2014-3572: OpenSSL downgrades ECDHE to ECDH
 //   - CVE-2011-3210: OpenSSL was not thread safe
-public class EcdhTest extends TestCase {
+public class EcdhTest {
 
   static final String[] ECDH_VARIANTS = {
     // Raw ECDH. The shared secret is the x-coordinate of the ECDH computation.
@@ -827,6 +829,7 @@ public class EcdhTest extends TestCase {
   };
 
   /** Checks that key agreement using ECDH works. */
+  @Test
   public void testBasic() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
     ECGenParameterSpec ecSpec = new ECGenParameterSpec("secp256r1");
@@ -845,6 +848,7 @@ public class EcdhTest extends TestCase {
     assertEquals(TestUtil.bytesToHex(kAB), TestUtil.bytesToHex(kBA));
   }
 
+  @Test
   public void testVectors() throws Exception {
     KeyAgreement ka = KeyAgreement.getInstance("ECDH");
     for (EcdhTestVector t : ECDH_TEST_VECTORS) {
@@ -859,6 +863,7 @@ public class EcdhTest extends TestCase {
     }
   }
 
+  @Test
   public void testDecode() throws Exception {
     KeyFactory kf = KeyFactory.getInstance("EC");
     ECPublicKey key1 = (ECPublicKey) kf.generatePublic(EC_VALID_PUBLIC_KEY.getSpec());
@@ -969,11 +974,13 @@ public class EcdhTest extends TestCase {
     }
   }
 
+  @Test
   public void testModifiedPublic() throws Exception {
     testModifiedPublic("ECDH");
     testModifiedPublic("ECDHC");
   }
 
+  @Test
   public void testModifiedPublicSpec() throws Exception {
     testModifiedPublicSpec("ECDH");
     testModifiedPublicSpec("ECDHC");
@@ -1113,11 +1120,13 @@ public class EcdhTest extends TestCase {
         "Algorithm:" + algorithm, TestUtil.bytesToHex(shared), TestUtil.bytesToHex(shared2));
   }
 
+  @Test
   public void testWrongOrderEcdh() throws Exception {
     testWrongOrder("ECDH", EcUtil.getNistP256Params());
     testWrongOrder("ECDH", EcUtil.getBrainpoolP256r1Params());
   }
 
+  @Test
   public void testWrongOrderEcdhc() throws Exception {
     testWrongOrder("ECDHC", EcUtil.getNistP256Params());
     testWrongOrder("ECDHC", EcUtil.getBrainpoolP256r1Params());

--- a/java/com/google/security/wycheproof/testcases/EcdsaTest.java
+++ b/java/com/google/security/wycheproof/testcases/EcdsaTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import com.google.security.wycheproof.WycheproofRunner.SlowTest;
 import java.lang.management.ManagementFactory;
@@ -35,7 +37,7 @@ import java.security.spec.ECParameterSpec;
 import java.security.spec.ECPoint;
 import java.security.spec.ECPublicKeySpec;
 import java.util.Arrays;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Tests ECDSA against invalid signatures.
@@ -50,7 +52,7 @@ import junit.framework.TestCase;
 // TODO(bleichen):
 //   - CVE-2015-2730: Firefox failed to handle some signatures correctly because of incorrect
 //     point multiplication. (I don't have enough information here.)
-public class EcdsaTest extends TestCase {
+public class EcdsaTest {
   // ECDSA-Key1
   static final String MESSAGE = "Hello";
   static final String CURVE = "secp256r1";
@@ -639,12 +641,14 @@ public class EcdsaTest extends TestCase {
     assertEquals(0, errors);
   }
 
+  @Test
   public void testValidSignatures() throws Exception {
     testVectors(
         VALID_SIGNATURES, publicKey1(), "Hello", "SHA256WithECDSA", "Valid ECDSA signature",
         true, true);
   }
 
+  @Test
   public void testModifiedSignatures() throws Exception {
     testVectors(
         MODIFIED_SIGNATURES,
@@ -656,6 +660,7 @@ public class EcdsaTest extends TestCase {
         true);
   }
 
+  @Test
   public void testInvalidSignatures() throws Exception {
     testVectors(
         INVALID_SIGNATURES,
@@ -671,6 +676,7 @@ public class EcdsaTest extends TestCase {
    * This test checks the basic functionality of ECDSA. It can also be used to generate simple test
    * vectors.
    */
+  @Test
   public void testBasic() throws Exception {
     String algorithm = "SHA256WithECDSA";
     String hashAlgorithm = "SHA-256";
@@ -778,6 +784,7 @@ public class EcdsaTest extends TestCase {
 
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.CONSCRYPT, ProviderType.OPENJDK,
     ProviderType.SPONGY_CASTLE})
+  @Test
   public void testBiasAll() throws Exception {
     testBias("SHA256WithECDSA", "secp256r1", EcUtil.getNistP256Params());
     testBias("SHA224WithECDSA", "secp224r1", EcUtil.getNistP224Params());
@@ -889,6 +896,7 @@ public class EcdsaTest extends TestCase {
 
   @SlowTest(providers = {ProviderType.BOUNCY_CASTLE, ProviderType.CONSCRYPT, ProviderType.OPENJDK,
     ProviderType.SPONGY_CASTLE})
+  @Test
   public void testTimingAll() throws Exception {
     testTiming("SHA256WithECDSA", "secp256r1", EcUtil.getNistP256Params());
     // TODO(bleichen): crypto libraries sometimes use optimized code for curves that are frequently

--- a/java/com/google/security/wycheproof/testcases/EciesTest.java
+++ b/java/com/google/security/wycheproof/testcases/EciesTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.KeyPair;
@@ -29,7 +31,7 @@ import java.security.spec.ECGenParameterSpec;
 import java.util.Arrays;
 import java.util.HashSet;
 import javax.crypto.Cipher;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Testing ECIES.
@@ -48,7 +50,7 @@ import junit.framework.TestCase;
 // - compressed points,
 // - maybe again CipherInputStream, CipherOutputStream,
 // - BouncyCastle has a KeyPairGenerator for ECIES. Is this one different from EC?
-public class EciesTest extends TestCase {
+public class EciesTest {
 
   int expectedCiphertextLength(String algorithm, int coordinateSize, int messageLength)
       throws Exception {
@@ -70,6 +72,7 @@ public class EciesTest extends TestCase {
    * both 128 bits.
    */
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testEciesBasic() throws Exception {
     ECGenParameterSpec ecSpec = new ECGenParameterSpec("secp256r1");
     KeyPairGenerator kf = KeyPairGenerator.getInstance("EC");
@@ -94,6 +97,7 @@ public class EciesTest extends TestCase {
   // TODO(bleichen): This test describes BouncyCastles behaviour, but not necessarily what we
   // expect.
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testInvalidNames() throws Exception {
     String[] invalidNames =
         new String[] {
@@ -118,6 +122,7 @@ public class EciesTest extends TestCase {
   // TODO(bleichen): This test describes BouncyCastles behaviour, but not necessarily what we
   // expect.
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testValidNames() throws Exception {
     String[] validNames =
         new String[] {
@@ -133,6 +138,7 @@ public class EciesTest extends TestCase {
    * BouncyCastle has a key generation algorithm "ECIES". This test checks that the result are
    * ECKeys in both cases.
    */
+  @Test
   public void testKeyGeneration() throws Exception {
     ECGenParameterSpec ecSpec = new ECGenParameterSpec("secp256r1");
     KeyPairGenerator kf = KeyPairGenerator.getInstance("ECIES");
@@ -194,11 +200,13 @@ public class EciesTest extends TestCase {
     assertEquals(1, exceptions.size());
   }
 
+  @Test
   public void testEciesCorruptDefault() throws Exception {
     testExceptions("ECIES");
   }
 
   @SuppressWarnings("InsecureCryptoUsage")
+  @Test
   public void testModifyPoint() throws Exception {
     ECGenParameterSpec ecSpec = new ECGenParameterSpec("secp256r1");
     KeyPairGenerator kf = KeyPairGenerator.getInstance("EC");
@@ -253,6 +261,7 @@ public class EciesTest extends TestCase {
     assertTrue("Ciphertext repeats:" + TestUtil.bytesToHex(ciphertext), !block1.equals(block2));
   }
 
+  @Test
   public void testDefaultEcies() throws Exception {
     testNotEcb("ECIES");
   }
@@ -291,6 +300,7 @@ public class EciesTest extends TestCase {
   }
 
   /** Tests whether two distinct algorithm names implement the same cipher */
+  @Test
   public void testAlias() throws Exception {
     testIsAlias("ECIESWITHAES-CBC", "ECIESWithAES-CBC");
     testIsAlias("ECIESWITHAES", "ECIESWithAES");

--- a/java/com/google/security/wycheproof/testcases/JsonSignatureTest.java
+++ b/java/com/google/security/wycheproof/testcases/JsonSignatureTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.gson.JsonElement;
@@ -30,14 +32,14 @@ import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
 import java.security.spec.X509EncodedKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * This test uses test vectors in JSON format to check digital signature schemes.
  * There are still a lot of open questions, e.g. the format for the test vectors is not
  * yet finalized. Therefore, we are not integrating the tests here into other tests
  */
-public class JsonSignatureTest extends TestCase {
+public class JsonSignatureTest {
 
   static protected String getString(JsonObject object, String name) throws Exception {
     return object.get(name).getAsString();
@@ -210,10 +212,12 @@ public class JsonSignatureTest extends TestCase {
     testVectors(tests, algorithm);
   }
 
+  @Test
   public void testEcdsa() throws Exception {
     testSignatureScheme("ecdsa_test.json", "ECDSA");
   }
 
+  @Test
   public void testRsaSignatures() throws Exception {
     testSignatureScheme("rsa_signature_test.json", "RSA");
   }

--- a/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
+++ b/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -24,7 +26,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * RSA encryption tests
@@ -36,7 +38,7 @@ import junit.framework.TestCase;
 // - plaintext too long
 // - ciphertext 0
 // - ciphertext == modulus timing attacks
-public class RsaEncryptionTest extends TestCase {
+public class RsaEncryptionTest {
 
   /**
    * Providers that implement RSA with PKCS1Padding but not OAEP are outdated and should be avoided
@@ -44,6 +46,7 @@ public class RsaEncryptionTest extends TestCase {
    * cipher. There is a great danger that PKCS1Padding is used as a temporary workaround, but later
    * stays in the project for much longer than necessary.
    */
+  @Test
   public void testOutdatedProvider() throws Exception {
     try {
       Cipher c = Cipher.getInstance("RSA/ECB/PKCS1Padding");
@@ -141,10 +144,12 @@ public class RsaEncryptionTest extends TestCase {
    * chosen message attacks. Nonetheless, to minimize the damage of such an attack an implementation
    * should minimize the information about the failure in the padding.
    */
+  @Test
   public void testExceptionsPKCS1() throws Exception {
     testExceptions("RSA/ECB/PKCS1PADDING");
   }
 
+  @Test
   public void testGetExceptionsOAEP() throws Exception {
     testExceptions("RSA/ECB/OAEPWITHSHA-1ANDMGF1PADDING");
   }

--- a/java/com/google/security/wycheproof/testcases/RsaKeyTest.java
+++ b/java/com/google/security/wycheproof/testcases/RsaKeyTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -25,7 +27,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /**
  * Tests RSA keys. Signatures and encryption are tested in different tests.
@@ -44,7 +46,7 @@ import junit.framework.TestCase;
 //    some libraries compute d mod lambda(n)
 //    paramaters p,q,... are not really required
 // - checks for bad random number generation
-public class RsaKeyTest extends TestCase {
+public class RsaKeyTest {
 
   public static final String ENCODED_PUBLIC_KEY =
     "30819f300d06092a864886f70d010101050003818d0030818902818100ab9014"
@@ -1454,6 +1456,7 @@ public class RsaKeyTest extends TestCase {
     checkKeyPair(keypair, keySizeInBits);
   }
 
+  @Test
   public void testKeyGeneration() throws Exception {
     testKeyGenerationSize(1024);
     testKeyGenerationSize(2048);
@@ -1466,6 +1469,7 @@ public class RsaKeyTest extends TestCase {
    * Such a failure does not need to be a bug, since several encoding for the same key are
    * possible.
    */
+  @Test
   public void testEncodeDecodePublic() throws Exception {
     KeyFactory kf = KeyFactory.getInstance("RSA");
     byte[] encoded = TestUtil.hexToBytes(ENCODED_PUBLIC_KEY);
@@ -1483,6 +1487,7 @@ public class RsaKeyTest extends TestCase {
    * This test has mostly "defense in depth" characteristic, since applications should
    * never accept unauthenticated public keys.
    */
+  @Test
   public void testModifiedPublicKeyDecoding() throws Exception {
     KeyFactory kf = KeyFactory.getInstance("RSA");
     int cnt = 0;

--- a/java/com/google/security/wycheproof/testcases/RsaSignatureTest.java
+++ b/java/com/google/security/wycheproof/testcases/RsaSignatureTest.java
@@ -16,6 +16,8 @@
 
 package com.google.security.wycheproof;
 
+import static org.junit.Assert.*;
+
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.KeyPair;
@@ -27,7 +29,7 @@ import java.security.SignatureException;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAPublicKeySpec;
-import junit.framework.TestCase;
+import org.junit.Test;
 
 /** Tests RSA signature schemes. */
 // TODO(bleichen):
@@ -35,7 +37,7 @@ import junit.framework.TestCase;
 // - So far only PKCS #1 signatures are tested. But RSA-PSS becomes more popular.
 // - document stuff
 // - Join other RSA tests
-public class RsaSignatureTest extends TestCase {
+public class RsaSignatureTest {
   static final RSAPublicKeySpec RSA_KEY1 =
       new RSAPublicKeySpec(
           new BigInteger(
@@ -1074,6 +1076,7 @@ public class RsaSignatureTest extends TestCase {
         + "0000",
   };
 
+  @Test
   public void testBasic() throws Exception {
     String algorithm = "SHA256WithRSA";
     String hashAlgorithm = "SHA-256";
@@ -1155,6 +1158,7 @@ public class RsaSignatureTest extends TestCase {
   }
 
   /** SunJCE threw an OutOfMemoryError with one of the signatures. */
+  @Test
   public void testVectorsAll() throws Exception {
     testVectors(RSA_KEY1, ALGORITHM_KEY1, SIGNATURES_KEY1);
   }
@@ -1187,6 +1191,7 @@ public class RsaSignatureTest extends TestCase {
    * https://groups.google.com/a/chromium.org/forum/#!topic/chromium-reviews/Jo5S7HtEABI claims that
    * 7% of the responses in the Online Certificate Status Protocol (OCSP) miss the NULL parameter
    */
+  @Test
   public void testLegacySignatures() throws Exception {
     RSAPublicKeySpec key = RSA_KEY1;
     String algorithm = ALGORITHM_KEY1;


### PR DESCRIPTION
- Remove `extends TestCase` which triggered usage of the JUnit3 runner
- Replace `import static org.junit.Assert.assertArrayEquals;` with `import static org.junit.Assert.*;`
- Replace `import junit.framework.TestCase;` with `import org.junit.Test;`
- Annotate all existing test methods (that are prefixed with 'test' and have no args) with `@Test`