### PR TITLE
Cipher add try catch

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,6 +28,26 @@ test_srcs = glob([
     "java/**/testcases/*Test.java",
 ])
 
+# wolfCrypt tests
+
+java_import(
+        name = "wolfcrypt_jar",
+        jars = ["wolfcrypt-jni.jar"],
+        visibility = ["//visibility:public"],
+        )
+
+java_test(
+        name = "WolfCryptAllTestsLocal",
+        size = "enormous",
+        srcs = ["java/com/google/security/wycheproof/WolfCryptAllTests.java"] + test_srcs,
+## this target requires specifing a shell variable, thus won't work with the wildcard target patterns.
+# with tags=["manual"] it'll be excluded from said patterns.
+        tags = ["manual"],
+        test_class = "com.google.security.wycheproof.WolfCryptAllTests",
+        deps = common_deps + ["//:wolfcrypt_jar"],
+        data = testdata,
+        )
+
 # Bouncy Castle tests
 load("//tools:build_defs.bzl", "bouncycastle_all_tests", "bouncycastle_tests")
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -32,19 +32,18 @@ test_srcs = glob([
 
 java_import(
         name = "wolfcrypt_jar",
-        jars = ["wolfcrypt-jni.jar"],
+        jars = ["third_party/wolfcrypt-jni/lib/wolfcrypt-jni.jar"],
         visibility = ["//visibility:public"],
         )
 
 java_test(
-        name = "WolfCryptAllTestsLocal",
+        name = "WolfCryptAllTests",
         size = "enormous",
-        srcs = ["java/com/google/security/wycheproof/WolfCryptAllTests.java"] + test_srcs,
-## this target requires specifing a shell variable, thus won't work with the wildcard target patterns.
-# with tags=["manual"] it'll be excluded from said patterns.
+        srcs = ["java/com/google/security/wycheproof/WolfCryptAllTests.java"]
+                 + test_srcs,
         tags = ["manual"],
         test_class = "com.google.security.wycheproof.WolfCryptAllTests",
-        deps = common_deps + ["//:wolfcrypt_jar"],
+        deps = common_deps + ["wolfcrypt_jar"],
         data = testdata,
         )
 

--- a/java/com/google/security/wycheproof/TestUtil.java
+++ b/java/com/google/security/wycheproof/TestUtil.java
@@ -90,9 +90,21 @@ public class TestUtil {
   }
 
   private static void installOpenJDKProvider(String className) throws Exception {
-    Provider provider = (Provider) Class.forName(className).getConstructor().newInstance();
-    Security.insertProviderAt(provider, 1);
+      Provider provider = (Provider) Class.forName(className).getConstructor().newInstance();
+      Security.insertProviderAt(provider, 1);
   }
+
+  public static void installOnlyWolfCryptProviders() throws Exception {
+      for (Provider p : Security.getProviders()) {
+          Security.removeProvider(p.getName());
+      }
+      installWolfCryptProvider("com.wolfssl.provider.jce.WolfCryptProvider");
+  }
+
+  private static void installWolfCryptProvider(String className) throws Exception {
+      Provider provider = (Provider) Class.forName(className).getConstructor().newInstance();
+      Security.insertProviderAt(provider, 1);
+ }
   
   public static void printJavaInformation() {
     System.out.println("Running with: ");

--- a/java/com/google/security/wycheproof/WolfCryptAllTests.java
+++ b/java/com/google/security/wycheproof/WolfCryptAllTests.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.security.wycheproof;
+
+import com.google.security.wycheproof.WycheproofRunner.Provider;
+import com.google.security.wycheproof.WycheproofRunner.ProviderType;
+import com.wolfssl.provider.jce.WolfCryptProvider;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * Tests for wolfSSL's crypto library: wolfCrypt
+ * wolfCryptAllTests runs all tests.
+ */
+@RunWith(WycheproofRunner.class)
+@SuiteClasses({
+//AesGcmTest.class, //need AES/GCM/NoPadding
+  BasicTest.class,
+//CipherInputStreamTest.class, //err constructing HashDRBG
+//CipherOutputStreamTest.class,  //err constructing HashDRBG
+//DhTest.class, //err constructing DH
+//DsaTest.class,  // DSA keyPairGenerator not available
+//EcKeyTest.class,
+//EcdhTest.class,
+//EcdsaTest.class,
+  JsonAeadTest.class,
+  JsonCipherTest.class,
+//JsonEcdhTest.class,
+  JsonKeyWrapTest.class,
+//JsonSignatureTest.class,
+//MessageDigestTest.class,
+//RsaEncryptionTest.class,
+//RsaKeyTest.class,
+//RsaSignatureTest.class
+})
+@Provider(ProviderType.WOLFCRYPT)
+public final class WolfCryptAllTests {
+  @BeforeClass
+  public static void setUp() throws Exception {
+    TestUtil.installOnlyThisProvider(new WolfCryptProvider());
+  }
+}

--- a/java/com/google/security/wycheproof/WolfCryptAllTests.java
+++ b/java/com/google/security/wycheproof/WolfCryptAllTests.java
@@ -26,29 +26,30 @@ import org.junit.runners.Suite.SuiteClasses;
  */
 @RunWith(WycheproofRunner.class)
 @SuiteClasses({
-//AesGcmTest.class, //need AES/GCM/NoPadding
-  BasicTest.class,
-//CipherInputStreamTest.class, //err constructing HashDRBG
-//CipherOutputStreamTest.class,  //err constructing HashDRBG
-//DhTest.class, //err constructing DH
-//DsaTest.class,  // DSA keyPairGenerator not available
-//EcKeyTest.class,
-//EcdhTest.class,
-//EcdsaTest.class,
-  JsonAeadTest.class,
-  JsonCipherTest.class,
-//JsonEcdhTest.class,
-  JsonKeyWrapTest.class,
-//JsonSignatureTest.class,
-//MessageDigestTest.class,
-//RsaEncryptionTest.class,
-//RsaKeyTest.class,
-//RsaSignatureTest.class
+//  AesGcmTest.class,             /* No Support. Skipped. */
+    BasicTest.class,
+//  CipherInputStreamTest.class,  /* SIG FAULT */
+//  CipherOutputStreamTest.class, /* SIG FAULT */
+    DhTest.class,
+//  DsaTest.class,                /* No Support. Skipped */
+    EcKeyTest.class,
+    EcdhTest.class,               /* 2 failures, 2 Ignored tests */
+    EcdsaTest.class,
+    JsonAeadTest.class,           /* Pass. no modification. Skips 2 AES. */
+    JsonCipherTest.class,         /* Pass. no modification. Skips 1 AES. */
+//  JsonEcdhTest.class,           /* Fail 1 test. No support EC KeyFactory */
+    JsonKeyWrapTest.class,
+    JsonSignatureTest.class,      /* 1/7 fail, secp and DSA ignored */
+//  MessageDigestTest.class,
+    RsaEncryptionTest.class,      /* RSA KeyPairGenerator skip 2, 1 crit. fail*/
+//  RsaKeyTest.class,       /*Fail all test. No RSA KeyFactory or KeyPairGenerator*/
+//  RsaSignatureTest.class  /*Fail all test. No RSA KeyFactory or KeyPairGenerator*/
 })
+
 @Provider(ProviderType.WOLFCRYPT)
 public final class WolfCryptAllTests {
   @BeforeClass
   public static void setUp() throws Exception {
-    TestUtil.installOnlyThisProvider(new WolfCryptProvider());
+    TestUtil.installOnlyWolfCryptProviders();
   }
 }

--- a/java/com/google/security/wycheproof/WycheproofRunner.java
+++ b/java/com/google/security/wycheproof/WycheproofRunner.java
@@ -50,6 +50,7 @@ public class WycheproofRunner extends Suite {
     CONSCRYPT,
     OPENJDK,
     SPONGY_CASTLE,
+    WOLFCRYPT,
   }
 
   // Annotations for test runners.

--- a/java/com/google/security/wycheproof/testcases/CipherInputStreamTest.java
+++ b/java/com/google/security/wycheproof/testcases/CipherInputStreamTest.java
@@ -222,26 +222,40 @@ public class CipherInputStreamTest {
 
   @Test
   public void testAesGcm() throws Exception {
+    final String algorithm = "AES/GCM/NoPadding";
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
     final int[] tagSizes = {12, 16};
     final int[] ptSizes = {0, 8, 16, 65, 8100};
     final int[] aadSizes = {0, 8, 24};
+    try {
+        Cipher.getInstance(algorithm);
+    } catch (NoSuchAlgorithmException ex) {
+        System.out.println("Skipping testAesGcm");
+        return;
+    }
     Iterable<TestVector> v =
-        getTestVectors("AES/GCM/NoPadding", keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
+        getTestVectors(algorithm, keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
     testEncrypt(v);
     testDecrypt(v);
   }
 
   @Test
   public void testCorruptAesGcm() throws Exception {
+    final String algorithm = "AES/GCM/NoPadding";
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
     final int[] tagSizes = {12, 16};
     final int[] ptSizes = {8, 16, 65, 8100};
     final int[] aadSizes = {0, 8, 24};
+    try {
+        Cipher.getInstance(algorithm);
+    } catch (NoSuchAlgorithmException ex) {
+        System.out.println("Skipping testCorruptAesGcm");
+        return;
+    }
     Iterable<TestVector> v =
-        getTestVectors("AES/GCM/NoPadding", keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
+        getTestVectors(algorithm, keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
     testCorruptDecrypt(v);
   }
 
@@ -252,13 +266,20 @@ public class CipherInputStreamTest {
    */
   @Test
   public void testEmptyPlaintext() throws Exception {
+    final String algorithm = "AES/GCM/NoPadding";
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
     final int[] tagSizes = {12, 16};
     final int[] ptSizes = {0};
     final int[] aadSizes = {0, 8, 24};
+    try {
+        Cipher.getInstance(algorithm);
+    } catch (NoSuchAlgorithmException ex) {
+        System.out.println("Skipping testEmptyPlaintext");
+        return;
+    }
     Iterable<TestVector> v =
-        getTestVectors("AES/GCM/NoPadding", keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
+        getTestVectors(algorithm, keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
     testCorruptDecryptEmpty(v);
   }
 

--- a/java/com/google/security/wycheproof/testcases/CipherOutputStreamTest.java
+++ b/java/com/google/security/wycheproof/testcases/CipherOutputStreamTest.java
@@ -189,13 +189,20 @@ public class CipherOutputStreamTest {
 
   @Test
   public void testAesGcm() throws Exception {
+    final String algorithm = "AES/GCM/NoPadding";
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
     final int[] tagSizes = {12, 16};
     final int[] ptSizes = {8, 16, 65, 8100};
     final int[] aadSizes = {0, 8, 24};
+    try {
+        Cipher.getInstance(algorithm);
+    } catch (NoSuchAlgorithmException ex) {
+        System.out.println("Skipping testAesGcm");
+        return;
+    }
     Iterable<TestVector> v =
-        getTestVectors("AES/GCM/NoPadding", keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
+        getTestVectors(algorithm, keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
     testEncrypt(v);
     testDecrypt(v);
     testCorruptDecrypt(v);
@@ -208,13 +215,20 @@ public class CipherOutputStreamTest {
    */
   @Test
   public void testEmptyPlaintext() throws Exception {
+    final String algorithm = "AES/GCM/NoPadding";
     final int[] keySizes = {16, 32};
     final int[] ivSizes = {12};
     final int[] tagSizes = {12, 16};
     final int[] ptSizes = {0};
     final int[] aadSizes = {0, 8, 24};
+    try {
+        Cipher.getInstance(algorithm);
+    } catch (NoSuchAlgorithmException ex) {
+        System.out.println("Skipping testEmptyPlaintext");
+        return;
+    }
     Iterable<TestVector> v =
-        getTestVectors("AES/GCM/NoPadding", keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
+        getTestVectors(algorithm, keySizes, ivSizes, tagSizes, ptSizes, aadSizes);
     testEncrypt(v);
     testDecrypt(v);
     testCorruptDecryptEmpty(v);

--- a/java/com/google/security/wycheproof/testcases/DhTest.java
+++ b/java/com/google/security/wycheproof/testcases/DhTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.security.wycheproof.WycheproofRunner.ExcludedTest;
 import com.google.security.wycheproof.WycheproofRunner.NoPresubmitTest;
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import com.google.security.wycheproof.WycheproofRunner.SlowTest;
@@ -197,6 +198,11 @@ public class DhTest {
   }
 
   /** Check that key agreement using DH works. */
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support DH KeyFactory.")
+
   @SuppressWarnings("InsecureCryptoUsage")
   @Test
   public void testDh() throws Exception {
@@ -369,6 +375,10 @@ public class DhTest {
   }
 
   /** This test tries a key agreement with keys using distinct parameters. */
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support DH KeyFactory.")
+
   @SuppressWarnings("InsecureCryptoUsage")
   @Test
   public void testDHDistinctParameters() throws Exception {
@@ -403,6 +413,11 @@ public class DhTest {
    *
    * <p>CVE-2016-1000346: BouncyCastle before v.1.56 did not validate the other parties public key.
    */
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support DH KeyFactory.")
+
   @SuppressWarnings("InsecureCryptoUsage")
   @Test
   public void testSubgroupConfinement() throws Exception {

--- a/java/com/google/security/wycheproof/testcases/EcKeyTest.java
+++ b/java/com/google/security/wycheproof/testcases/EcKeyTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.security.wycheproof.WycheproofRunner.ExcludedTest;
+import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import java.math.BigInteger;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyFactory;
@@ -131,6 +133,10 @@ public class EcKeyTest {
         + "8c0b49bbb85c3303ddb1553c3b761c2caacca71606ba9ebac8",
   };
 
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
   @Test
   public void testEncodedPublicKey() throws Exception {
     KeyFactory kf = KeyFactory.getInstance("EC");
@@ -146,6 +152,10 @@ public class EcKeyTest {
       }
     }
   }
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
 
   @Test
   public void testEncodedPrivateKey() throws Exception {

--- a/java/com/google/security/wycheproof/testcases/EcdhTest.java
+++ b/java/com/google/security/wycheproof/testcases/EcdhTest.java
@@ -17,6 +17,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import com.google.security.wycheproof.WycheproofRunner.NoPresubmitTest;
+import com.google.security.wycheproof.WycheproofRunner.ExcludedTest;
+import com.google.security.wycheproof.WycheproofRunner.NoPresubmitTest;
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import java.math.BigInteger;
 import java.security.GeneralSecurityException;
@@ -1859,6 +1861,11 @@ public static final EcPublicKeyTestVector EC_VALID_PUBLIC_KEY =
   };
 
   /** Checks that key agreement using ECDH works. */
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
   @Test
   public void testBasic() throws Exception {
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
@@ -1892,14 +1899,23 @@ public static final EcPublicKeyTestVector EC_VALID_PUBLIC_KEY =
       }
     }
   }
-  @Test
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
+ @Test
   public void testEncode() throws Exception {
     KeyFactory kf = KeyFactory.getInstance("EC");
     ECPublicKey valid = (ECPublicKey) kf.generatePublic(EC_VALID_PUBLIC_KEY.getSpec());
     assertEquals(TestUtil.bytesToHex(valid.getEncoded()), EC_VALID_PUBLIC_KEY.encoded);
   }
 
-  @Test
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
+ @Test
   public void testDecode() throws Exception {
     KeyFactory kf = KeyFactory.getInstance("EC");
     ECPublicKey key1 = (ECPublicKey) kf.generatePublic(EC_VALID_PUBLIC_KEY.getSpec());

--- a/java/com/google/security/wycheproof/testcases/EcdsaTest.java
+++ b/java/com/google/security/wycheproof/testcases/EcdsaTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.security.wycheproof.WycheproofRunner.ExcludedTest;
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import com.google.security.wycheproof.WycheproofRunner.SlowTest;
 import java.lang.management.ManagementFactory;
@@ -642,6 +643,10 @@ public class EcdsaTest {
     assertEquals(0, errors);
   }
 
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
   @Test
   public void testValidSignatures() throws Exception {
     testVectors(
@@ -654,7 +659,11 @@ public class EcdsaTest {
         true);
   }
 
-  @Test
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
+ @Test
   public void testModifiedSignatures() throws Exception {
     testVectors(
         MODIFIED_SIGNATURES,
@@ -665,6 +674,10 @@ public class EcdsaTest {
         false,
         true);
   }
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
 
   @Test
   public void testInvalidSignatures() throws Exception {
@@ -682,6 +695,11 @@ public class EcdsaTest {
    * This test checks the basic functionality of ECDSA. It can also be used to generate simple test
    * vectors.
    */
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
   @Test
   public void testBasic() throws Exception {
     String algorithm = "SHA256WithECDSA";
@@ -793,7 +811,8 @@ public class EcdsaTest {
       ProviderType.BOUNCY_CASTLE,
       ProviderType.CONSCRYPT,
       ProviderType.OPENJDK,
-      ProviderType.SPONGY_CASTLE
+      ProviderType.SPONGY_CASTLE,
+      ProviderType.WOLFCRYPT
     }
   )
   @Test
@@ -911,7 +930,8 @@ public class EcdsaTest {
       ProviderType.BOUNCY_CASTLE,
       ProviderType.CONSCRYPT,
       ProviderType.OPENJDK,
-      ProviderType.SPONGY_CASTLE
+      ProviderType.SPONGY_CASTLE,
+      ProviderType.WOLFCRYPT
     }
   )
   @Test

--- a/java/com/google/security/wycheproof/testcases/JsonSignatureTest.java
+++ b/java/com/google/security/wycheproof/testcases/JsonSignatureTest.java
@@ -259,40 +259,72 @@ public class JsonSignatureTest {
     }
   }
 
+
   @Test
   public void testEcdsa() throws Exception {
     testSignatureScheme("ecdsa_test.json", "ECDSA", true);
   }
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
 
   @Test
   public void testSecp224r1Sha224() throws Exception {
     testSignatureScheme("ecdsa_secp224r1_sha224_test.json", "ECDSA", false);
   }
 
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
+
   @Test
   public void testSecp224r1Sha256() throws Exception {
     testSignatureScheme("ecdsa_secp224r1_sha256_test.json", "ECDSA", false);
   }
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
 
   @Test
   public void testSecp256r1Sha256() throws Exception {
     testSignatureScheme("ecdsa_secp256r1_sha256_test.json", "ECDSA", false);
   }
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
 
   @Test
   public void testSecp384r1Sha384() throws Exception {
     testSignatureScheme("ecdsa_secp384r1_sha384_test.json", "ECDSA", false);
   }
 
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
+
   @Test
   public void testSecp384r1Sha512() throws Exception {
     testSignatureScheme("ecdsa_secp384r1_sha512_test.json", "ECDSA", false);
   }
 
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
+
+
   @Test
   public void testSecp521r1Sha512() throws Exception {
     testSignatureScheme("ecdsa_secp521r1_sha512_test.json", "ECDSA", false);
   }
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support EC KeyFactory.")
 
   // Testing curves that may not be supported by a provider.
   @Test
@@ -333,8 +365,9 @@ public class JsonSignatureTest {
 
   // Testing DSA signatures.
   @ExcludedTest(
-    providers = {ProviderType.CONSCRYPT},
-    comment = "Conscrypt does not support DSA.")
+    providers = {ProviderType.CONSCRYPT, ProviderType.WOLFCRYPT},
+    comment = "Conscrypt and wolfCrypt does not support DSA.")
+
   @Test
   public void testDsa() throws Exception {
     testSignatureScheme("dsa_test.json", "DSA", false);

--- a/java/com/google/security/wycheproof/testcases/MessageDigestTest.java
+++ b/java/com/google/security/wycheproof/testcases/MessageDigestTest.java
@@ -16,12 +16,14 @@ package com.google.security.wycheproof;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import com.google.security.wycheproof.WycheproofRunner.ExcludedTest;
 import com.google.security.wycheproof.WycheproofRunner.ProviderType;
 import com.google.security.wycheproof.WycheproofRunner.SlowTest;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -207,6 +209,10 @@ public class MessageDigestTest {
     testMessageDigest("SHA-1");
   }
 
+  @ExcludedTest(
+    providers = {ProviderType.WOLFCRYPT},
+    comment = "wolfCrypt does not support SHA-224.")
+
   @Test
   public void testSha224() throws Exception {
     testMessageDigest("SHA-224");
@@ -279,10 +285,11 @@ public class MessageDigestTest {
     byte[] digest = hashRepeatedMessage(algorithm, bytes, repetitions);
     String hexdigest = TestUtil.bytesToHex(digest);
     assertEquals(expected, hexdigest);
-  }
+  }               
 
   @SlowTest(
-    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE}
+    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE,
+       ProviderType.SPONGY_CASTLE, ProviderType.WOLFCRYPT}
   )
   @Test
   public void testLongMessageMd5() throws Exception {
@@ -291,7 +298,8 @@ public class MessageDigestTest {
   }
 
   @SlowTest(
-    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE}
+    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE,
+        ProviderType.SPONGY_CASTLE, ProviderType.WOLFCRYPT}
   )
   @Test
   public void testLongMessageSha1() throws Exception {
@@ -300,7 +308,8 @@ public class MessageDigestTest {
   }
 
   @SlowTest(
-    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE}
+    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE,
+        ProviderType.SPONGY_CASTLE, ProviderType.WOLFCRYPT}
   )
   @Test
   public void testLongMessageSha256() throws Exception {
@@ -317,8 +326,13 @@ public class MessageDigestTest {
   }
 
   @SlowTest(
-    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE}
+    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE,
+        ProviderType.SPONGY_CASTLE}
   )
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support SHA-224.")
+
   @Test
   public void testLongMessageSha224() throws Exception {
     testLongMessage(
@@ -328,8 +342,10 @@ public class MessageDigestTest {
   }
 
   @SlowTest(
-    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE}
+    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE,
+        ProviderType.SPONGY_CASTLE, ProviderType.WOLFCRYPT}
   )
+
   @Test
   public void testLongMessageSha384() throws Exception {
     testLongMessage(
@@ -347,7 +363,8 @@ public class MessageDigestTest {
   }
 
   @SlowTest(
-    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE, ProviderType.SPONGY_CASTLE}
+    providers = {ProviderType.OPENJDK, ProviderType.BOUNCY_CASTLE, 
+        ProviderType.SPONGY_CASTLE, ProviderType.WOLFCRYPT}
   )
   @Test
   public void testLongMessageSha512() throws Exception {

--- a/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
+++ b/java/com/google/security/wycheproof/testcases/RsaEncryptionTest.java
@@ -15,6 +15,8 @@ package com.google.security.wycheproof;
 
 import static org.junit.Assert.fail;
 
+import com.google.security.wycheproof.WycheproofRunner.ProviderType;
+import com.google.security.wycheproof.WycheproofRunner.ExcludedTest;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -144,10 +146,18 @@ public class RsaEncryptionTest {
    * chosen message attacks. Nonetheless, to minimize the damage of such an attack an implementation
    * should minimize the information about the failure in the padding.
    */
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support RSA KeyPairGenerator.")
+
   @Test
   public void testExceptionsPKCS1() throws Exception {
     testExceptions("RSA/ECB/PKCS1PADDING");
   }
+
+  @ExcludedTest(
+  providers = {ProviderType.WOLFCRYPT},
+  comment = "wolfCrypt does not support RSA KeyPairGenerator.")
 
   @Test
   public void testGetExceptionsOAEP() throws Exception {


### PR DESCRIPTION
Created try catch statements so that the test would skip when provider does not support the algorithms such as AES/GCM/NoPadding.