### PR TITLE
Fix spurious errors in ECIES byte buffer tests

### DIFF
--- a/java/com/google/security/wycheproof/testcases/EciesTest.java
+++ b/java/com/google/security/wycheproof/testcases/EciesTest.java
@@ -378,7 +378,7 @@ public class EciesTest {
     // Decryption
     ctBuffer.flip();
     ByteBuffer decrypted = ByteBuffer.allocate(message.length);
-    cipher.init(Cipher.DECRYPT_MODE, priv);
+    cipher.init(Cipher.DECRYPT_MODE, priv, cipher.getParameters());
     cipher.doFinal(ctBuffer, decrypted);
     assertEquals(TestUtil.bytesToHex(message), TestUtil.bytesToHex(decrypted.array()));
   }
@@ -414,7 +414,7 @@ public class EciesTest {
     ecies.doFinal(ptBuffer, ctBuffer);
     ctBuffer.flip();
 
-    ecies.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+    ecies.init(Cipher.DECRYPT_MODE, keyPair.getPrivate(), ecies.getParameters());
     byte[] decrypted = ecies.doFinal(backingArray, 0, ctBuffer.remaining());
     assertEquals(TestUtil.bytesToHex(message), TestUtil.bytesToHex(decrypted));
   }


### PR DESCRIPTION
The two ECIES byte buffer tests always fail with the following error:

```
9) testByteBuffer(com.google.security.wycheproof.EciesTest)
java.lang.IllegalArgumentException: cannot handle supplied parameter spec: NONCE in IES Parameters needs to be 16 bytes long
        at org.bouncycastle.jcajce.provider.asymmetric.ec.IESCipher.engineInit(Unknown Source)
        at javax.crypto.Cipher.init(Cipher.java:1245)
        at javax.crypto.Cipher.init(Cipher.java:1185)
        at com.google.security.wycheproof.EciesTest.testByteBuffer(EciesTest.java:381)
        ...
```

Unless I've seriously misunderstood these tests, this is caused by a simple oversight in the `Cipher.init()` calls for the decryptions. Like all the other ECIES decryptions in this file, these need the algorithm parameters from the encryption step (which includes the nonce mentioned in the error message). With this change, both tests pass on BC 1.59 and 1.62. On 1.52 they still fail with the same unrelated error as before, several lines earlier.